### PR TITLE
add tests for all application render and limit parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://hawaiian-homes-tracker.onrender.com/applications
 Node.js, Mongoose, MongoDB Atlas, Express, nodemon, morgan, winston, postman, jsonwebtoken, bcrypt, cors, helmet, custom rate limiter, dotenv.
 
 ## Testing
-Mocha, Chai, and Supertest are used for testing. Please refer to this file for the test codes.
+Mocha, Chai, and Supertest are used for testing. Please refer to this file for the tests code.
 [Test files](./test/api.test.js)
 
 ## REST API - Flow Chart

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "type": "module",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "mocha",
+    "test:watch": "mocha --watch"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,0 +1,30 @@
+import {expect}  from 'chai'
+import api from './testHelper.js'
+
+
+
+describe('GET/api/applications', () =>{
+    let res;
+
+    it("should return all applications from the database", async function (){
+        res = await api
+        .get('/applications')
+        .expect(200)
+        .expect('Content-type', /application\/json/)
+        expect(res.body.applications).to.be.an('array')
+    })
+
+    it("should return applications from custom page with limit params", async function(){
+       
+        const page = 2
+        const limit = 5
+
+       res = await api
+        .get('/applications')
+        .query({page,limit})
+        .expect('Content-type', /json/)
+        .expect(200)
+        expect(res.body.applications).to.be.an('array')
+        expect(res.body.applications.length).to.be.at.most(limit)
+    })
+})

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -1,0 +1,3 @@
+import request from 'supertest'
+const api = request ('https://hawaiian-homes-tracker.onrender.com')
+export default api


### PR DESCRIPTION
Closes #5 


describe('GET/api/applications', () =>{
    let res;

    it("should return all applications from the database", async function (){
        res = await api
        .get('/applications')
        .expect(200)
        .expect('Content-type', /application\/json/)
        expect(res.body.applications).to.be.an('array')
    })

    it("should return applications from custom page with limit params", async function(){
       
        const page = 2
        const limit = 5

       res = await api
        .get('/applications')
        .query({page,limit})
        .expect('Content-type', /json/)
        .expect(200)
        expect(res.body.applications).to.be.an('array')
        expect(res.body.applications.length).to.be.at.most(limit)
    })